### PR TITLE
hermes support

### DIFF
--- a/typescript/package.json
+++ b/typescript/package.json
@@ -3,8 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "sei-open-close-position": "ts-node ./src/main/open-close-position.ts --networkId=sei-testnet",
-    "osmosis-open-close-position": "ts-node ./src/main/open-close-position.ts --networkId=osmosis-testnet"
+    "sei-open-close-position": "ts-node ./src/main/open-close-position.ts --networkId=sei-testnet --marketId=ETH_USD",
+    "osmosis-open-close-position": "ts-node ./src/main/open-close-position.ts --networkId=osmosis-testnet --marketId=OSMO_USDC"
   },
   "dependencies": {
     "@cosmjs/cosmwasm-stargate": "^0.30.1",

--- a/typescript/src/config.ts
+++ b/typescript/src/config.ts
@@ -4,7 +4,7 @@ import { getArg} from "./utils/cmd";
 
 dotenv.config({ path: path.resolve(__dirname, "../../.env") });
 
-export const PYTH_ENDPOINT = "https://pyth.sandbox.levana.finance/";
+export const PYTH_ENDPOINT = "https://hermes.pyth.network/";
 
 export const NETWORKS: Record<NetworkId, NetworkConfig> = {
     "sei-testnet": {
@@ -16,10 +16,9 @@ export const NETWORKS: Record<NetworkId, NetworkConfig> = {
         "denom": "usei",
         "chain_id": "atlantic-2",
         "addr_prefix": "sei",
-        "market_id": "ETH_USD",
     },
     "osmosis-testnet": {
-        "factory": "osmo1jd5m5c5pf8zfkpe0dpw5fhx7lncmp5l9qsm22dr87s08e6dacz7q92sys2",
+        "factory": "osmo165nre6njgve474xa4m2xvfgjln77xgcn4jgyltgmy2h3tyggsmjsyl9qrs",
         "rpc_url": "https://rpc.osmotest5.osmosis.zone",
         "rest_url": "https://lcd.osmotest5.osmosis.zone",
         "gas_price": "0.025",
@@ -27,7 +26,6 @@ export const NETWORKS: Record<NetworkId, NetworkConfig> = {
         "denom": "uosmo",
         "chain_id": "osmo-test-5",
         "addr_prefix": "osmo",
-        "market_id": "ATOM_USD",
     }
 }
 
@@ -51,7 +49,6 @@ export interface NetworkConfig {
     "denom": string,
     "chain_id": string, 
     "addr_prefix": string,
-    "market_id": string 
 }
 
 export type NetworkId = "sei-testnet" | "osmosis-testnet";

--- a/typescript/src/main/open-close-position.ts
+++ b/typescript/src/main/open-close-position.ts
@@ -1,17 +1,19 @@
-import { getNetworkConfig } from "../config";
+import { getArg } from "../utils/cmd";
 import { Factory } from "../wrappers/factory";
 import { Market } from "../wrappers/market";
 
 (async () => {
     const factory = await Factory.Create();
 
-    const market = await Market.Create(factory, getNetworkConfig().market_id);
+    const market = await Market.Create(factory, getArg("marketId"));
 
     const collateralBalance = await market.queryCollateralBalance();
     console.log(`collateral balance before opening: ${collateralBalance}`);
 
-    // deposit 10% of collateral balance or 10 collateral, whichever is smaller
-    const collateralDeposit = Math.min(Number(collateralBalance) * 0.1, 10);
+    // deposit 10% of collateral balance or 20 collateral, whichever is smaller
+    // note - this may need to be adjusted so that the minimum is above
+    // the market minimum, which is in terms of 5 USD
+    const collateralDeposit = Math.min(Number(collateralBalance) * 0.1, 20);
 
     const {positionId, res: openRes} = await market.execOpenPosition({
         collateral: collateralDeposit.toString(),


### PR DESCRIPTION
This migrates to the new hermes support and pyth_bridge format, testable via `yarn osmosis-open-close-position`

It does _not_ do the same thing the frontend does of supporting both formats.

Also, it uses the osmoci factory... 

I'm putting this in draft mode for now, should be easy to just change the factory address and move into proper PR when all the testnet contracts have migrated over

@lvn-rusty-dragon - heads up, did this both in case it comes up next week while I'm out, and it was simpler for me to test things here before moving over to frontend proper